### PR TITLE
Add option nrow(label)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-_v. 1.1.3_  
+_v. 1.2.0_  
 
 `btable` <img src='sticker.png' align="right" height="200">
 ========

--- a/btable.pkg
+++ b/btable.pkg
@@ -3,7 +3,7 @@ d 'BTABLE': btable
 d 
 d Summary tables
 d 
-d Distribution-Date:   20231001
+d Distribution-Date:   20231003
 d License: Academic Free License v3.0
 d 
 F RMST.ado

--- a/btable.pkg
+++ b/btable.pkg
@@ -1,9 +1,9 @@
-v 1.1.3
+v 1.2.0
 d 'BTABLE': btable
 d 
 d Summary tables
 d 
-d Distribution-Date:   20230918
+d Distribution-Date:   20231001
 d License: Academic Free License v3.0
 d 
 F RMST.ado

--- a/btable.sthlp
+++ b/btable.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.0.1  10oct2022}{...}
+{* *! version 1.0.2 01oct2023}{...}
 {hline}
 {cmd:help btable} {right:also see:  {help btable_format}}
 {hline}
@@ -110,7 +110,8 @@ See {manhelp btable_format R:btable_format} for formatting the table after gener
 
 {pstd}
 Descriptives include 
-number of events (stored in variables starting with nlev),
+the toal number of observations (ntot) for all variables,
+number of events (nlev),
 	proportion of events (pr) and confidence interval of the proportion (prlci and pruci) for categorical variables, 
 mean (mean), median (p50), standard deviation (sd), quartiles (p25 and p75), interquartile range (iqr),
 	minimum (min), maximum (max), range (range), sum (sum) 

--- a/btable_format.ado
+++ b/btable_format.ado
@@ -1,11 +1,11 @@
-*! version 1.2.0 01oct2023
+*! version 1.2.0 03oct2023
 cap program drop btable_format
 program btable_format, nclass
 
 version 16
 
 syntax using [, clear ///
-	ncol(string) drop(string) nametot(string) nrow(string) NROWHead ///
+	ncol(string) drop(string) nametot(string) nrows(string) NROWhead ///
 	design(string) inset(string) inset_row(string) parse(string) ///
 	DEScriptive(string) EFFect(string) ///
 	DIGits(string)  CATDigits0(string) ///
@@ -706,12 +706,12 @@ foreach inptype of local inptypelist {
 qui replace `nrowvar'=`nrowvar'[_n+1] if varname==varname[_n+1] & vtype=="cat1"
 
 //count maximal number of measures
-local nrows=1
+local norows=1
 local ca = reverse(subinstr(reverse("`ca'"),",","",1))
 matrix CA = `ca'
 mata : st_matrix("CB", rowmax(st_matrix("CA")))
-if (CB[1,1]>`nrows') {
-	local nrows = CB[1,1]
+if (CB[1,1]>`norows') {
+	local norows = CB[1,1]
 }
 
 if `anyparse'==1 {
@@ -721,20 +721,20 @@ if `anyparse'==1 {
 		local design row
 	}
 }
-if "`nrow'"!="" {
+if "`nrows'"!="" {
 	cap assert inlist("`design'","missing","row","long")
 	if _rc {
-		dis as text "Design `design' not allowed with nrow, row is used."
+		dis as text "Design `design' not allowed with nrows, row is used."
 		local design row
 	}
 }
 	
 //nrows per variable?
 //list varname vtype `nrowvar'
-//dis "`nrows'"
+//dis "`norows'"
 //exit
  
-forvalues mrow = 1/`nrows' {
+forvalues mrow = 1/`norows' {
 	
 	foreach inptype of local inptypelist {
 		
@@ -1693,8 +1693,8 @@ qui replace levlabel=varname if missing(levlabel) & inlist(vtype,"cat1","conti",
 
 if "`collapse'" != "" {
 
-	if "`nrow'"!="" {
-		dis as text "Collapsing is not  possible if option nrow is specified."
+	if "`nrows'"!="" {
+		dis as text "Collapsing is not  possible if option nrows is specified."
 	}
 	else {
 		collapse_cat, collapse(`collapse') collapselevv(`collapselevv') design(`design')
@@ -1726,7 +1726,7 @@ if "`p_all'"=="" {
 *design row or column or missing
 **************************
 //on level of locals
-//apply_design, design(`design') nrows(`nrows') inset_row("`inset_row'") inset("`inset'")
+//apply_design, design(`design') norows(`norows') inset_row("`inset_row'") inset("`inset'")
 
 //on level of variables
 //on level of vars
@@ -1741,7 +1741,7 @@ if "`p_all'"=="" {
 apply_design_var, nrowvar(`nrowvar') design(`design') inset_row("`inset_row'") inset("`inset'") ///
 	nonmiss(`nonmiss') varname_sp(`varname_sp') denom(`denom') ///
 	namemiss(`namemiss') digits_miss(`digits_miss') digits_type_miss(`digits_type_miss') maxdec_miss(`maxdec_miss') ///
-	ft_type(`ft_type') catdigits0(`catdigits0') format_miss(`format_miss') nrow(`nrow')
+	ft_type(`ft_type') catdigits0(`catdigits0') format_miss(`format_miss') nrows(`nrows')
 	
 	
 *headers
@@ -3345,7 +3345,7 @@ cap program drop apply_design_var
 program apply_design_var, nclass
 syntax [, nrowvar(varname) design(string) inset(string) inset_row(string) nonmiss(string) varname_sp(varname) ///
 	namemiss(string) denom(string) digits_miss(string) digits_type_miss(string) maxdec_miss(string) ///
-	ft_type(string) CATDigits0(string) format_miss(string) nrow(string)]
+	ft_type(string) CATDigits0(string) format_miss(string) nrows(string)]
 
 
 if "`nrowvar'"=="" {
@@ -3490,15 +3490,15 @@ foreach var of varlist ntot* {
 *add row for n
 tempvar nins 
 
-if "`nrow'"!="" {
+if "`nrows'"!="" {
 	qui replace `seq' = _n
 	qui expand 2 if vtype=="cat1", gen(`nins')
 	qui replace `seq' = `seq' + 0.01 if `nins'==1
 	qui sort `seq'
 	qui replace vtype="cat" if `nins'==1
 	
-	qui replace levlabel="`inset'" + "`nrow'" if `nins'==1
-	qui replace desc_info="`nrow'" if `nins'==1
+	qui replace levlabel="`inset'" + "`nrows'" if `nins'==1
+	qui replace desc_info="`nrows'" if `nins'==1
 
 	foreach var of varlist ntot* {
 		local pos=strpos("`var'","_")+1
@@ -3605,7 +3605,7 @@ qui gen     `expf' = `nrowvar' if inlist(vtype,"conti","tte","count")
 qui replace `expf' = `nrowvar' + 1 + `miss' if `miss' == 1  & inlist(vtype,"conti","tte","count")
 qui replace `expf' = `nrowvar' + 1  if `miss' == 0 & `nrowvar'>1 & inlist(vtype,"conti","tte","count")
 
-if "`nrow'"!="" {
+if "`nrows'"!="" {
 	qui replace `expf' = `expf' + 1 if `expf'>2 & inlist(vtype,"conti","tte","count")
 	qui replace `expf' = `expf' + 2 if `expf'==1 & inlist(vtype,"conti","tte","count")
 }
@@ -3619,7 +3619,7 @@ sort `seq' `srow'
 tempvar nc
 qui gen `nc' = `expf' - `miss'
 
-if "`nrow'"!="" {
+if "`nrows'"!="" {
 	qui replace `nc' = `nc' - 1
 	qui replace `srow' = 1.5 if `srow'==2
 	qui replace `srow' = `srow'-1 if `srow'>2
@@ -3675,7 +3675,7 @@ qui replace levlabel="`inset'" + "missing" + "`inset_row'" + desc_info  ///
 
 
 *n in first row 
-if "`nrow'"!="" {
+if "`nrows'"!="" {
 	foreach var of local elist {
 		cap replace `var' = "" if  inlist(vtype,"conti","tte","count") & `srow'==1.5
 	}
@@ -3688,8 +3688,8 @@ if "`nrow'"!="" {
 		qui replace out_`na' = string(nnonmiss_`na') ///
 			if inlist(vtype,"conti","tte","count") & `srow'==1.5
 	}
-	qui replace desc_info = "`nrow'" if  inlist(vtype,"conti","tte","count") & `srow'==1.5
-	qui replace levlabel="`inset'" + "`nrow'"   ///
+	qui replace desc_info = "`nrows'" if  inlist(vtype,"conti","tte","count") & `srow'==1.5
+	qui replace levlabel="`inset'" + "`nrows'"   ///
 		if inlist(vtype,"conti","tte","count") & `srow'==1.5
 
 }

--- a/btable_format.ado
+++ b/btable_format.ado
@@ -1,11 +1,11 @@
-*! version 1.1.3 18sep2023
+*! version 1.2.0 01oct2023
 cap program drop btable_format
 program btable_format, nclass
 
 version 16
 
 syntax using [, clear ///
-	ncol(string) drop(string) nametot(string) nrow  ///
+	ncol(string) drop(string) nametot(string) nrow(string) NROWHead ///
 	design(string) inset(string) inset_row(string) parse(string) ///
 	DEScriptive(string) EFFect(string) ///
 	DIGits(string)  CATDigits0(string) ///
@@ -718,6 +718,13 @@ if `anyparse'==1 {
 	cap assert inlist("`design'","missing","row","long")
 	if _rc {
 		dis as text "Design `design' not allowed with more than one descriptive measure per variable, row is used."
+		local design row
+	}
+}
+if "`nrow'"!="" {
+	cap assert inlist("`design'","missing","row","long")
+	if _rc {
+		dis as text "Design `design' not allowed with nrow, row is used."
 		local design row
 	}
 }
@@ -1448,7 +1455,7 @@ forvalues mrow = 1/`nrows' {
 	qui replace `labels' = subinstr(`labels',"`a'","%",.)
 	qui replace `labels' = subinstr(`labels',"`rp'","%",.)
 	qui replace `labels' = subinstr(`labels',"nlev","n",.) if vtype=="cat"
-	qui replace `labels' = subinstr(`labels',"ntot","N",.) if vtype=="cat"
+	qui replace `labels' = subinstr(`labels',"ntot","N",.) //if vtype=="cat"
 	qui replace `labels' = subinstr(`labels',"nevents","n",.) if vtype=="count"
 	qui replace `labels' = subinstr(`labels',"etime","person-time",.) if vtype=="count"
 	qui replace `labels' = subinstr(`labels',"nfails","failures",.) if vtype=="tte"
@@ -1685,17 +1692,21 @@ qui replace levlabel=varname if missing(levlabel) & inlist(vtype,"cat1","conti",
 //list varname vtype levlabel nlev out_d*
 
 if "`collapse'" != "" {
-	
-	collapse_cat, collapse(`collapse') collapselevv(`collapselevv') design(`design')
 
-	if "`nobracket'"!="" {
-		foreach db of local nobracket {
-			qui replace levlabel=subinstr(levlabel," (`db')","",.)
-		}
+	if "`nrow'"!="" {
+		dis as text "Collapsing is not  possible if option nrow is specified."
 	}
-	
-	cap drop seq	
+	else {
+		collapse_cat, collapse(`collapse') collapselevv(`collapselevv') design(`design')
 
+		if "`nobracket'"!="" {
+			foreach db of local nobracket {
+				qui replace levlabel=subinstr(levlabel," (`db')","",.)
+			}
+		}
+		
+		cap drop seq	
+	}
 }
 
 
@@ -1730,7 +1741,7 @@ if "`p_all'"=="" {
 apply_design_var, nrowvar(`nrowvar') design(`design') inset_row("`inset_row'") inset("`inset'") ///
 	nonmiss(`nonmiss') varname_sp(`varname_sp') denom(`denom') ///
 	namemiss(`namemiss') digits_miss(`digits_miss') digits_type_miss(`digits_type_miss') maxdec_miss(`maxdec_miss') ///
-	ft_type(`ft_type') catdigits0(`catdigits0') format_miss(`format_miss')
+	ft_type(`ft_type') catdigits0(`catdigits0') format_miss(`format_miss') nrow(`nrow')
 	
 	
 *headers
@@ -1783,7 +1794,7 @@ if "`ncol'" != "" {
 
 	local insl 1
 	empty_line in 1, position("before")
-	if "`nrow'"=="" {
+	if "`nrowhead'"=="" {
 		qui replace ns_t="`nametot' (N = `nt')" in 1
 		qui replace out_t="`nametot' (N = `nt')" in 1
 		local nkeep ns_t
@@ -1835,7 +1846,7 @@ else {
 	local nkeep
 	local insl 1
 	empty_line in 1, position("before")
-	if "`nrow'"=="" {
+	if "`nrowhead'"=="" {
 		qui replace out_t="`nametot' (N = `nt')" in 1
 		if `ngroups'>=1 {
 			forvalues i=1/`ngroups' {
@@ -3334,7 +3345,7 @@ cap program drop apply_design_var
 program apply_design_var, nclass
 syntax [, nrowvar(varname) design(string) inset(string) inset_row(string) nonmiss(string) varname_sp(varname) ///
 	namemiss(string) denom(string) digits_miss(string) digits_type_miss(string) maxdec_miss(string) ///
-	ft_type(string) CATDigits0(string) format_miss(string)]
+	ft_type(string) CATDigits0(string) format_miss(string) nrow(string)]
 
 
 if "`nrowvar'"=="" {
@@ -3397,7 +3408,7 @@ if "`design'"=="missing"   {
 tempvar expf
 tempvar seq 
 tempvar srow
-tempvar nrow
+tempvar nnrow
  
 *cat
 ************
@@ -3417,7 +3428,7 @@ foreach var of local elist {
 	cap replace `var' = "" if `lastrow'==1 & `miss'==1
 }
 
- 
+
 cap genloc2, input(`ft_type') key(miss)
 if !_rc {
 	local meas `r(meas)'
@@ -3476,22 +3487,47 @@ foreach var of varlist ntot* {
 	qui drop `nlev' `ntot' `prop' `perc' 
 } 
 
+*add row for n
+tempvar nins 
+
+if "`nrow'"!="" {
+	qui replace `seq' = _n
+	qui expand 2 if vtype=="cat1", gen(`nins')
+	qui replace `seq' = `seq' + 0.01 if `nins'==1
+	qui sort `seq'
+	qui replace vtype="cat" if `nins'==1
+	
+	qui replace levlabel="`inset'" + "`nrow'" if `nins'==1
+	qui replace desc_info="`nrow'" if `nins'==1
+
+	foreach var of varlist ntot* {
+		local pos=strpos("`var'","_")+1
+		local na=substr("`var'",`pos',.)
+		qui replace out_`na' = string(nnonmiss_`na') if `nins'==1
+	}	
+}
+else {
+	qui gen `nins'=.
+}
+
 *expand for more than one descriptive
 qui replace `seq' = _n
 qui bysort varname (`seq'): gen `srow' = _n 
-qui bysort varname (`srow'): gen `nrow' = _N 
+qui bysort varname (`srow'): gen `nnrow' = _N 
 sort `seq'
+
+//list varname level vtype `nrowvar' `nnrow'
 
 qui gen `expf' = `nrowvar' if inlist(vtype,"cat","cat1")
 //for collapsed, additional row
-qui replace `expf' = `nrowvar' + 1 if `nrowvar'>1 & `nrow'==1 & inlist(vtype,"cat","cat1")
+qui replace `expf' = `nrowvar' + 1 if `nrowvar'>1 & `nnrow'==1 & inlist(vtype,"cat","cat1")
 
 tempvar expanded
 qui expand `expf', gen(`expanded')
 
 tempvar seq_exp
 qui bysort `seq' (`expanded'): gen `seq_exp' = _n if `expanded'==1
-qui replace `seq' = `seq' + `nrow' - `srow' + `srow'/`nrow' - 0.0000001  if `expanded'==1
+qui replace `seq' = `seq' + `nnrow' - `srow' + `srow'/`nnrow' - 0.0000001  if `expanded'==1
 sort `seq' `seq_exp'
 
 local nmax=1
@@ -3500,7 +3536,7 @@ if `r(N)' != 0 {
 	local nmax = `r(max)'
 }
 
-//list varname `srow' `nrow' `miss' `seq_exp'
+//list varname `srow' `nnrow' `miss' `seq_exp'
 cap ds pv
 if _rc {
 	qui ds out_? *_info
@@ -3514,26 +3550,26 @@ else {
 
 if `nmax'>1 {
 	tempvar norep
-	qui gen `norep' = 1 if `miss'==1 & `lastrow'==1
+	qui gen `norep' = 1 if (`miss'==1 & `lastrow'==1) | `nins'==1
 	
 	//collapsed with more than 1 row
 	foreach var of local vlist {
-		qui replace `var' = "" if `nrow'==1 & vtype=="cat1" & `nrowvar'>1 & `seq_exp'==.
+		qui replace `var' = "" if `nnrow'==1 & vtype=="cat1" & `nrowvar'>1 & `seq_exp'==.
 	
 	}
 	
 	forvalues k = 2/`nmax' {
 		foreach var of local vlist {
-			cap replace `var' = `var'_v`k' if `seq_exp'==`k' & `norep' != 1 & `nrow'!=1
+			cap replace `var' = `var'_v`k' if `seq_exp'==`k' & `norep' != 1 & `nnrow'!=1
 			
 			//collapses with more than 1 row
 			if `k'>2 {
 				local l=`k'-1
-				qui replace `var' = `var'_v`l' if `seq_exp'==`k' & `norep' != 1 & `nrow'==1
+				qui replace `var' = `var'_v`l' if `seq_exp'==`k' & `norep' != 1 & `nnrow'==1
 			}
 		}
 		//collapsed label
-		qui replace levlabel = "`inset'" + desc_info if `seq_exp'==`k' & `nrow'==1
+		qui replace levlabel = "`inset'" + desc_info if `seq_exp'==`k' & `nnrow'==1
 	
 	}
 } 
@@ -3541,20 +3577,23 @@ if `nmax'>1 {
 //list varname levlabel desc_info vtype `nrow' `seq_exp'
 
 if "`design'"!="column" {
-	qui replace levlabel=levlabel + "`inset_row'" + desc_info[_n+1] if vtype=="cat1" & `nrow'>1
+	qui replace levlabel=levlabel + "`inset_row'" + desc_info[_n+1] if vtype=="cat1" & `nnrow'>1 & `nins'[_n+1]!=1
+	qui replace levlabel=levlabel + "`inset_row'" + desc_info[_n+2] if vtype=="cat1" & `nnrow'>1 & `nins'[_n+1]==1
+	
 	qui replace levlabel=levlabel + "`inset_row'" + desc_info ///
-		if vtype=="cat1" & `nrow'==1 & !missing(desc_info) & `seq_exp'==.
+		if vtype=="cat1" & `nnrow'==1 & !missing(desc_info) & `seq_exp'==. 
+	qui replace levlabel=levlabel + "`inset_row'" + desc_info ///
+		if vtype=="cat1" & `nnrow'==1 & !missing(desc_info) & `seq_exp'==.	
 }
 
 //collapsed
-//qui replace levlabel=levlabel + "`inset_row'" + desc_info if vtype=="cat1" & `nrow'==1 
-
+//qui replace levlabel=levlabel + "`inset_row'" + desc_info if vtype=="cat1" & `nnrow'==1 
 
 
 cap drop `expf' 
 cap drop `seq'
 cap drop `srow'
-cap drop `nrow'
+cap drop `nnrow'
 cap drop `lastrow'
 
  
@@ -3567,19 +3606,29 @@ qui gen     `expf' = `nrowvar' if inlist(vtype,"conti","tte","count")
 qui replace `expf' = `nrowvar' + 1 + `miss' if `miss' == 1  & inlist(vtype,"conti","tte","count")
 qui replace `expf' = `nrowvar' + 1  if `miss' == 0 & `nrowvar'>1 & inlist(vtype,"conti","tte","count")
 
+if "`nrow'"!="" {
+	qui replace `expf' = `expf' + 1 if `expf'>2 & inlist(vtype,"conti","tte","count")
+	qui replace `expf' = `expf' + 2 if `expf'==1 & inlist(vtype,"conti","tte","count")
+}
+
 qui expand `expf'
 
 sort `seq'
 qui bysort varname (`seq'): gen `srow' = _n 
-qui bysort varname (`srow'): gen `nrow' = _N 
+qui bysort varname (`srow'): gen `nnrow' = _N 
 sort `seq' `srow'
 tempvar nc
 qui gen `nc' = `expf' - `miss'
 
+if "`nrow'"!="" {
+	qui replace `nc' = `nc' - 1
+	qui replace `srow' = 1.5 if `srow'==2
+	qui replace `srow' = `srow'-1 if `srow'>2
+}
 
 *missings in last row		
 foreach var of local elist {
-	cap replace `var' = "" if  inlist(vtype,"conti","tte","count") & `srow'==`nrow' & `miss'==1
+	cap replace `var' = "" if  inlist(vtype,"conti","tte","count") & `srow'==`nnrow' & `miss'==1
 }
 
 foreach var of varlist ntot* {
@@ -3611,19 +3660,40 @@ foreach var of varlist ntot* {
 		local digforce 1
 	}
 	
-	formatting2 `vc' if  inlist(vtype,"conti","tte","count") & `srow'==`nrow' & `miss'==1, ///
+	formatting2 `vc' if  inlist(vtype,"conti","tte","count") & `srow'==`nnrow' & `miss'==1, ///
 						gen(`outh') ft(`ftm') ///
 						digits(`digits_miss') digits_type(`digits_type_miss') maxdec(`maxdec_miss') ///
 						dig_force0(`digforce') catdigits0(`catdigits0') format(`format_miss')
 						
-	qui replace out_`na' = `outh' if  inlist(vtype,"conti","tte","count") & `srow'==`nrow' & `miss'==1	
+	qui replace out_`na' = `outh' if  inlist(vtype,"conti","tte","count") & `srow'==`nnrow' & `miss'==1	
 	qui drop `nlev' `ntot' `prop' `perc' 
 	
-	qui replace desc_info = "`outm'" if  inlist(vtype,"conti","tte","count") & `srow'==`nrow' & `miss'==1
+	qui replace desc_info = "`outm'" if  inlist(vtype,"conti","tte","count") & `srow'==`nnrow' & `miss'==1
 }
 	
 qui replace levlabel="`inset'" + "missing" + "`inset_row'" + desc_info  ///
-	 if inlist(vtype,"conti","tte","count") & `srow'==`nrow' & `miss'==1
+	 if inlist(vtype,"conti","tte","count") & `srow'==`nnrow' & `miss'==1
+
+
+*n in first row 
+if "`nrow'"!="" {
+	foreach var of local elist {
+		cap replace `var' = "" if  inlist(vtype,"conti","tte","count") & `srow'==1.5
+	}
+
+	//list varname varlabel vtype `srow'
+	
+	foreach var of varlist ntot* {	
+		local pos=strpos("`var'","_")+1
+		local na=substr("`var'",`pos',.)
+		qui replace out_`na' = string(nnonmiss_`na') ///
+			if inlist(vtype,"conti","tte","count") & `srow'==1.5
+	}
+	qui replace desc_info = "`nrow'" if  inlist(vtype,"conti","tte","count") & `srow'==1.5
+	qui replace levlabel="`inset'" + "`nrow'"   ///
+		if inlist(vtype,"conti","tte","count") & `srow'==1.5
+
+}
 
 
 *all the other rows

--- a/btable_format.ado
+++ b/btable_format.ado
@@ -3574,7 +3574,7 @@ if `nmax'>1 {
 	}
 } 
 
-//list varname levlabel desc_info vtype `nrow' `seq_exp'
+//list varname levlabel desc_info vtype `nnrow' `seq_exp'
 
 if "`design'"!="column" {
 	qui replace levlabel=levlabel + "`inset_row'" + desc_info[_n+1] if vtype=="cat1" & `nnrow'>1 & `nins'[_n+1]!=1
@@ -3582,8 +3582,7 @@ if "`design'"!="column" {
 	
 	qui replace levlabel=levlabel + "`inset_row'" + desc_info ///
 		if vtype=="cat1" & `nnrow'==1 & !missing(desc_info) & `seq_exp'==. 
-	qui replace levlabel=levlabel + "`inset_row'" + desc_info ///
-		if vtype=="cat1" & `nnrow'==1 & !missing(desc_info) & `seq_exp'==.	
+		
 }
 
 //collapsed

--- a/btable_format.sthlp
+++ b/btable_format.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.1.0  07nov2022}{...}
+{* *! version 1.2.0 01oct2023}{...}
 {hline}
 {cmd:help btable_format} {right:also see:  {help btable}}
 {hline}
@@ -25,10 +25,11 @@
 
 {syntab:Main}
 {synopt: {opt clear}}replace data in memory{p_end}
-{synopt: {opt ncol:(header)}}creates a column with the number of observation with the indicated {it:header}{p_end}
+{synopt: {opt ncol:(header)}}creates a column with the number of non-missing observation called {it:header}{p_end}
+{synopt: {opt nrow:(label)}}creates a row with the number of non-missing observation labelled {it:label}{p_end}
 {synopt: {cmdab:drop(}{it:{help btable_format##colspec:colspec}}{cmd:)}}columns to drop from the output table{p_end}
 {synopt: {opt nametot(string)}}name of the column with all entries, default is "Total"{p_end}
-{synopt: {opt nrow}}inserts an extra row for the total number of observations {p_end}
+{synopt: {opt nrowh:ead}}inserts an extra row for the total number of observations {p_end}
 {synopt:{cmdab:design(}{it:{help btable_format##designspec:designspec}}{cmd:)}}design of the table,
 	{it:column} (default), {it:row} or {it:missing}{p_end}
 {synopt: {opt inset(string)}}inset of category labels, default is "    " {p_end}
@@ -136,7 +137,11 @@ P-values are only available if {it:groupvar} used with {cmd:btable} had at least
 {opt clear} replace the data in memory
 
 {phang}
-{opt ncol:(header)} creates a column with the number of observation with the indicated {it:header}.
+{opt ncol:(header)} creates a column with the number of non-missing observation called {it:header}.
+
+{phang}
+{opt nrow:(label)} creates a row with the number of non-missing observation for each variable labelled {it:label}. 
+	Needs {cmd:design} {cmd:row} or {cmd:missing}.
 
 {marker colspec}{...}
 {phang}
@@ -150,7 +155,7 @@ P-values are only available if {it:groupvar} used with {cmd:btable} had at least
 {opt nametot(string)} defines the name of the column that contains all groups. The default is "Total". {p_end}
 		
 {phang}	
-{opt nrow} inserts an extra row for the total number of observations. The default is to show it in brackets 
+{opt nrowh:ead} inserts an extra row for the total number of observations. The default is to show it in brackets 
 	after the column label. {p_end}
 	
 {marker designspec}{...}
@@ -198,6 +203,7 @@ where {it:varspec} is {cmdab:cat}, {cmdab:conti}, {cmd:count}, {cmd:tte}, {it:va
 	Available descriptives are:
 
 {phang3}
+	{cmd:ntot} (total number of observation),
 	{cmd:mean}, {cmd:sd} (standard deviation), {cmd:meanlci} and {cmd:meanuci} (lower and upper confidence limits
 	for the mean), {cmd:median}, {cmd:lq} (lower quartile), {cmd:uq} (upper quartile), {cmd:iqr} (interquartile range),
 	{cmd:min}, {cmd:max}, {cmd:range} and {cmd:sum}	for continuous variables,
@@ -209,11 +215,13 @@ where {it:varspec} is {cmdab:cat}, {cmdab:conti}, {cmd:count}, {cmd:tte}, {it:va
 	and {cmd:prop} (proportion) and confidence intervals ({cmd:proplci} and {cmd:propuci})
 	for categorical variables,
 		
-{phang3}				
+{phang3}
+	{cmd:ntot} (total number of observation), 
 	{cmd:nevents} (number of events), {cmd:etime} (exposure time), and 
 	{cmd:ir} (incidence rate) and confidence intervals ({cmd:irlci} and {cmd:iruci}) for count variables,
 
-{phang3}			
+{phang3}	
+	{cmd:ntot} (total number of observation),		
 	{cmd:nfails} (number of failures), {cmd:stime} (follow-up time), 
 	{cmd:st50} (median survival time) and confidence intervals ({cmd:st50lci} and {cmd:st50uci}) or
 	lower and upper quartile ({cmd:st25} and {cmd:st75}), and 
@@ -552,6 +560,8 @@ Several maximal number of digits can be specified for a variable type or a speci
 {phang}{cmd:. btable_format using "excars", clear desc(conti median [lq, uq] mpg mean (sd)) drop(total effect)}{p_end}
 
 {phang}{cmd:. btable_format using "excars", clear ncol(non-missing) drop(total effect info)}{p_end}
+
+{phang}{cmd:. btable_format using "excars", clear nrow(non-missing) design(row) drop(total effect info)}{p_end}
 
 {phang}{cmd:. btable_format using "excars", clear design(missing) drop(total effect info)}{p_end}
 

--- a/btable_format.sthlp
+++ b/btable_format.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 01oct2023}{...}
+{* *! version 1.2.0 03oct2023}{...}
 {hline}
 {cmd:help btable_format} {right:also see:  {help btable}}
 {hline}
@@ -26,10 +26,10 @@
 {syntab:Main}
 {synopt: {opt clear}}replace data in memory{p_end}
 {synopt: {opt ncol:(header)}}creates a column with the number of non-missing observation called {it:header}{p_end}
-{synopt: {opt nrow:(label)}}creates a row with the number of non-missing observation labelled {it:label}{p_end}
+{synopt: {opt nrows:(label)}}creates rows with the number of non-missing observations labelled {it:label}{p_end}
 {synopt: {cmdab:drop(}{it:{help btable_format##colspec:colspec}}{cmd:)}}columns to drop from the output table{p_end}
 {synopt: {opt nametot(string)}}name of the column with all entries, default is "Total"{p_end}
-{synopt: {opt nrowh:ead}}inserts an extra row for the total number of observations {p_end}
+{synopt: {opt nrow:head}}inserts an extra row for the total number of observations {p_end}
 {synopt:{cmdab:design(}{it:{help btable_format##designspec:designspec}}{cmd:)}}design of the table,
 	{it:column} (default), {it:row} or {it:missing}{p_end}
 {synopt: {opt inset(string)}}inset of category labels, default is "    " {p_end}
@@ -140,8 +140,9 @@ P-values are only available if {it:groupvar} used with {cmd:btable} had at least
 {opt ncol:(header)} creates a column with the number of non-missing observation called {it:header}.
 
 {phang}
-{opt nrow:(label)} creates a row with the number of non-missing observation for each variable labelled {it:label}. 
-	Needs {cmd:design} {cmd:row} or {cmd:missing}.
+{opt nrows:(label)} creates rows with the number of non-missing observations for each variable. 
+	The rows are labelled with {it:label}. 
+	Needs {cmd:design} {cmd:row} or {cmd:missing} (cmd:row is used by default).
 
 {marker colspec}{...}
 {phang}
@@ -155,7 +156,7 @@ P-values are only available if {it:groupvar} used with {cmd:btable} had at least
 {opt nametot(string)} defines the name of the column that contains all groups. The default is "Total". {p_end}
 		
 {phang}	
-{opt nrowh:ead} inserts an extra row for the total number of observations. The default is to show it in brackets 
+{opt nrow:head} inserts an extra row for the total number of observations. The default is to show it in brackets 
 	after the column label. {p_end}
 	
 {marker designspec}{...}
@@ -561,7 +562,7 @@ Several maximal number of digits can be specified for a variable type or a speci
 
 {phang}{cmd:. btable_format using "excars", clear ncol(non-missing) drop(total effect info)}{p_end}
 
-{phang}{cmd:. btable_format using "excars", clear nrow(non-missing) design(row) drop(total effect info)}{p_end}
+{phang}{cmd:. btable_format using "excars", clear nrows(non-missing) design(row) drop(total effect info)}{p_end}
 
 {phang}{cmd:. btable_format using "excars", clear design(missing) drop(total effect info)}{p_end}
 

--- a/make.do
+++ b/make.do
@@ -13,7 +13,7 @@ do "00_masterfile.do"
 *generate make file 
 cd ".."
 
-make btable, replace toc pkg version(1.1.3)                           ///
+make btable, replace toc pkg version(1.2.0)                           ///
      license("Academic Free License v3.0")                                   ///
      author("Lukas Bütikofer")                                              ///
      affiliation("CTU Bern")                                                 ///

--- a/stata.toc
+++ b/stata.toc
@@ -1,4 +1,4 @@
-v 1.1.3
+v 1.2.0
 d Materials by Lukas Bütikofer
 d CTU Bern
 d lukas.buetikofer@ctu.unibe.ch


### PR DESCRIPTION
New option to add a row with number of non-missing observations to all variables in the table. The old option nrow to get an additional header line has been replaced with nrowhead.